### PR TITLE
Add Aeon to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[aeon](https://github.com/aeonfun/aeon) | ![GitHub Repo stars](https://badgen.net/github/stars/aeonfun/aeon) | Autonomous agent framework that runs entirely on GitHub Actions with cron-scheduled Markdown skills, self-healing, and fleet replication | Autonomous agent framework|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adding **[aeon](https://github.com/aeonfun/aeon)** under **Framework Extensions**.

Aeon is an autonomous agent framework that runs entirely on GitHub Actions, with no long-lived server. Cron-scheduled Markdown skills self-heal (a health skill detects failures and a repair skill fixes them by PR), spawn a fleet of clones, and ship 70+ Agent Skills across six coding-agent harnesses (Claude Code default, plus Grok, Codex, Pi, Vibe, Kimi).

- Repo: https://github.com/aeonfun/aeon
- License: MIT · 666 stars · actively maintained (daily commits)
- Fits Framework Extensions: it is an agent/orchestration framework in the same family as claude-flow and claude-simone already listed here.

Appended to the Framework Extensions table, single entry, columns match the existing rows (Name | Stars | Description | Notes).