### PR TITLE
Add claude-forge to Framework Extensions

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -125,6 +125,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code 超能力：核心技能库 | 核心技能库|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Claude Code 的专业 AI 子代理集合 | 专业子代理|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | 用于 Claude Code 的自定义子代理 | 自定义子代理|
+|[claude-forge](https://github.com/sangrokjung/claude-forge) | ![GitHub Repo stars](https://badgen.net/github/stars/sangrokjung/claude-forge) | 一键安装的 Claude Code 配置框架，包含 agents、命令、skills 和安全 hooks | 配置框架|
 
 ## MCP服务器与插件
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[claude-forge](https://github.com/sangrokjung/claude-forge) | ![GitHub Repo stars](https://badgen.net/github/stars/sangrokjung/claude-forge) | Setup framework bundling agents, commands, skills, and safety hooks for Claude Code in one install | Configuration framework|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adding claude-forge (https://github.com/sangrokjung/claude-forge) to the
Framework Extensions table, in both README.md and README-CN.md.

It's an MIT-licensed configuration framework for Claude Code: agents, slash
commands, skills, and safety hooks in a single install, plus an adversarial
review loop (a second agent reviews without seeing the first one's reasoning).

Disclosure: I'm the author.