### PR TITLE
Add claude-skills-pro — engineering skills pack (15 skills, CN handbook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection) | ![GitHub Repo stars](https://badgen.net/github/stars/davepoon/claude-code-subagents-collection) | Claude Code Subagents & Commands Collection + CLI Tool | Subagents CLI tool|
 |[awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/vijaythecoder/awesome-claude-agents) | Orchestrated sub agent dev team powered by claude code | Sub agent dev team|
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
+|[claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) | ![GitHub Repo stars](https://badgen.net/github/stars/Hahaknight/claude-skills-pro) | 15 battle-tested engineering skills for Claude Code, with Chinese handbook | Engineering skills pack|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
 


### PR DESCRIPTION
Adds [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) to Framework Extensions, next to superpowers (same category: skills library). 15 engineering-workflow skills for Claude Code — code review, debugging, test generation, safe migrations — with a Chinese practical handbook; 7 samples free under MIT. 安装即用，附中文实战手册。
