### PR TITLE
Add claude-ai-agents-ios to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [简体中文](README-CN.md)
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
+|[claude-ai-agents-ios](https://github.com/apexbymanish/claude-ai-agents-ios) | ![GitHub Repo stars](https://badgen.net/github/stars/apexbymanish/claude-ai-agents-ios) | iOS/Swift-specialized Claude Code subagents & skills with an evidence-tiered claim-verification system | iOS/Swift subagents collection|
 
 ## MCP Servers & Plugins
 


### PR DESCRIPTION
Adds [claude-ai-agents-ios](https://github.com/apexbymanish/claude-ai-agents-ios) to the Framework Extensions section, alongside the other subagent-collection entries already listed there (VoltAgent/awesome-claude-code-subagents, wshobson/agents, etc.).

It's a set of Claude Code subagents & Skills specialized for iOS/Swift/Xcode development (architecture, testing, memory/performance, security, App Store readiness, Tuist project generation), with a seven-tier evidence taxonomy every agent reports claims against.