### PR TITLE
Add context-economy to Monitoring & Analytics

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -93,6 +93,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Claude Code 使用的成本跟踪 | 成本跟踪工具|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | 将 Claude Code 聊天会话导出为 markdown 和 XML | 会话导出工具|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | 监控 Claude Code 使用、性能和成本的综合可观察性解决方案 | 可观察性解决方案|
+|[context-economy](https://github.com/talcaldeg/context-economy) | ![GitHub Repo stars](https://badgen.net/github/stars/talcaldeg/context-economy) | 只读脚本，读取 Claude Code 自身的 .jsonl 会话记录，衡量 token 消耗的去向，并按占用上下文的多少对工具结果排序 | Token 消耗分析|
 
 ## 代理与API工具
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[context-economy](https://github.com/talcaldeg/context-economy) | ![GitHub Repo stars](https://badgen.net/github/stars/talcaldeg/context-economy) | Read-only scripts that measure where a Claude Code session's tokens go, reading its own .jsonl transcripts and ranking the tool results that carry the most context | Token consumption analysis|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds [context-economy](https://github.com/talcaldeg/context-economy) to the Monitoring & Analytics section, in both `README.md` and `README-CN.md`.

Three read-only Python scripts that read the `.jsonl` transcripts Claude Code already writes to `~/.claude/projects` and report where the tokens went: per-session cost split between producing output and re-reading context, and a ranking of individual tool results by *carry* (result tokens x the turns that came after them). Nothing is sent anywhere and nothing is modified. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)