### PR TITLE
Add ClawMetry to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[clawmetry](https://github.com/vivekchand/clawmetry) | ![GitHub Repo stars](https://badgen.net/github/stars/vivekchand/clawmetry) | Self-hosted observability dashboard and kill switch for Claude Code and other coding agents, reads the session logs the runtime already writes on disk so there is no SDK and nothing in the request path | Local-first observability tool|
 
 ## Proxy & API Tools
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
-|[clawmetry](https://github.com/vivekchand/clawmetry) | ![GitHub Repo stars](https://badgen.net/github/stars/vivekchand/clawmetry) | Self-hosted observability dashboard and kill switch for Claude Code and other coding agents, reads the session logs the runtime already writes on disk so there is no SDK and nothing in the request path | Local-first observability tool|
+|[clawmetry](https://github.com/vivekchand/clawmetry) | ![GitHub Repo stars](https://badgen.net/github/stars/vivekchand/clawmetry) | Self-hosted observability dashboard and kill switch for Claude Code and other coding agents, reads the session logs the runtime already writes on disk so there is no SDK and nothing in the request path | Local-first observability tool, [clawmetry.com](https://clawmetry.com)|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
[ClawMetry](https://github.com/vivekchand/clawmetry) ([clawmetry.com](https://clawmetry.com), MIT, open-core) is a self-hosted, local-first observability dashboard and kill switch for Claude Code and other coding-agent runtimes (OpenClaw, NemoClaw, Codex, Cursor, Gemini CLI, Aider, Goose, Hermes, OpenCode, Cline, Copilot and others). `pip install clawmetry && clawmetry`, zero config. It fits Monitoring & Analytics alongside claude-code-otel and sniffly: it shows sessions, transcripts, tool calls, tokens and cache-aware cost per session and per model, and the Guard tab can pause, stop or kill a runaway agent (opt-in, off by default).

How it gets its data, and why it differs from proxies and SDKs: it reads the session logs the runtimes already write on disk. No SDK to install, nothing sits in the request path, and nothing leaves the machine by default (cloud sync is optional and E2E-encrypted). Pricing, stated plainly: OpenClaw and NemoClaw are free in the open-source app; the other runtimes, including Claude Code, need ClawMetry Cloud or a self-hosted Pro license. One row added to the table, matching the existing format; README-CN.md was left untouched, happy to add a Chinese row too if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr
