### PR TITLE
Add chrome-bridge: let any AI agent drive your real logged-in Chrome

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -82,6 +82,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Claude Code 通信工具 | 通信工具|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | 通过电子邮件、discord、telegram 远程控制 Claude Code | 远程控制工具|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Claude code 和 Codex 的零配置代码流 | 零配置工作流|
+|[chrome-bridge](https://github.com/siropkin/chrome-bridge)|![GitHub Repo stars](https://badgen.net/github/stars/siropkin/chrome-bridge)|零依赖 Node CLI + 小巧 Chrome 扩展,让任意 AI 智能体(Claude Code、Cursor、Qwen Code、GLM 等)驱动你已登录的真实 Chrome;带元素引用的无障碍树快照比截图省约 10 倍 token|开源 MIT|
 
 ## 监控与分析
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ English | [简体中文](README-CN.md)
 |[Claude-Code-Communication](https://github.com/nishimoto265/Claude-Code-Communication) | ![GitHub Repo stars](https://badgen.net/github/stars/nishimoto265/Claude-Code-Communication) | Communication utilities for Claude Code | Communication tools|
 |[Claude-Code-Remote](https://github.com/JessyTsui/Claude-Code-Remote) | ![GitHub Repo stars](https://badgen.net/github/stars/JessyTsui/Claude-Code-Remote) | Control Claude Code remotely via email, discord, telegram | Remote control tool|
 |[zcf](https://github.com/UfoMiao/zcf) | ![GitHub Repo stars](https://badgen.net/github/stars/UfoMiao/zcf) | Zero-Config Code Flow for Claude code & Codex | Zero-config workflow|
+|[chrome-bridge](https://github.com/siropkin/chrome-bridge)|![GitHub Repo stars](https://badgen.net/github/stars/siropkin/chrome-bridge)|Zero-dependency Node CLI + tiny Chrome extension that lets any AI agent (Claude Code, Cursor, Qwen Code, GLM...) drive your real logged-in browser; a11y-tree snapshots with element refs, ~10x cheaper on tokens than screenshots|Open source, MIT|
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
Adds chrome-bridge to Development Tools & Utilities in both the English and 简体中文 READMEs. It is a zero-dependency Node CLI + tiny Chrome extension that lets any AI agent (Claude Code, Cursor, Qwen Code, GLM, ...) drive the real logged-in browser with a11y-tree snapshots and element refs (~10x cheaper on tokens than screenshots). MIT, no commercial funnel — the repo is the tool. 中文条目已同步加入 README-CN。