### PR TITLE
Add tokenchit to Monitoring & Analytics

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -93,6 +93,7 @@ Claude Code 是 Anthropic 推出的智能编程助手，它生活在你的终端
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Claude Code 使用的成本跟踪 | 成本跟踪工具|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | 将 Claude Code 聊天会话导出为 markdown 和 XML | 会话导出工具|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | 监控 Claude Code 使用、性能和成本的综合可观察性解决方案 | 可观察性解决方案|
+|[tokenchit](https://github.com/iyashjayesh/tokenchit) | ![GitHub Repo stars](https://badgen.net/github/stars/iyashjayesh/tokenchit) | 读取本地 Claude Code、Codex 和 OpenCode 日志，生成可提交到仓库的 token 使用量统计卡片 | 统计卡片生成工具|
 
 ## 代理与API工具
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-costs](https://github.com/philipp-spiess/claude-code-costs) | ![GitHub Repo stars](https://badgen.net/github/stars/philipp-spiess/claude-code-costs) | Cost tracking for Claude Code usage | Cost tracking tool|
 |[cctrace](https://github.com/jimmc414/cctrace) | ![GitHub Repo stars](https://badgen.net/github/stars/jimmc414/cctrace) | Export Claude Code chat sessions into markdown and XML | Session export tool|
 |[claude-code-otel](https://github.com/ColeMurray/claude-code-otel) | ![GitHub Repo stars](https://badgen.net/github/stars/ColeMurray/claude-code-otel) | Comprehensive observability solution for monitoring Claude Code usage, performance, and costs | Observability solution|
+|[tokenchit](https://github.com/iyashjayesh/tokenchit) | ![GitHub Repo stars](https://badgen.net/github/stars/iyashjayesh/tokenchit) | Reads local Claude Code, Codex and OpenCode logs and renders a token-usage card committed into your repo | Stat card generator|
 
 ## Proxy & API Tools
 


### PR DESCRIPTION
Adds [tokenchit](https://github.com/iyashjayesh/tokenchit) to Monitoring & Analytics, in both README.md and README-CN.md so the two tables stay in step.

It reads local Claude Code, Codex and OpenCode session logs and renders an SVG stat card that gets committed into the repository as a file, rather than embedded from a hosted endpoint — so the card still renders if the service is down. Parsing is local and covers token counts and timestamps only, never prompts or code. Publishing to the public leaderboard is a separate opt-in command, with an `unpublish` that deletes the row and the account.

- MIT licensed
- Install: `npx -y @tokenchit/cli@latest generate`