### PR TITLE
Add i-hate-editing to Framework Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ English | [简体中文](README-CN.md)
 |[claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection) | ![GitHub Repo stars](https://badgen.net/github/stars/davepoon/claude-code-subagents-collection) | Claude Code Subagents & Commands Collection + CLI Tool | Subagents CLI tool|
 |[awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/vijaythecoder/awesome-claude-agents) | Orchestrated sub agent dev team powered by claude code | Sub agent dev team|
 |[superpowers](https://github.com/obra/superpowers) | ![GitHub Repo stars](https://badgen.net/github/stars/obra/superpowers) | Claude Code superpowers: core skills library | Core skills library|
+|[i-hate-editing](https://github.com/ranahaani/i-hate-editing) | ![GitHub Repo stars](https://badgen.net/github/stars/ranahaani/i-hate-editing) | Claude Code skill: raw talking-head → finished cut via local whisper.cpp + ffmpeg (model never watches pixels) | Video editing skill|
 |[claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/lst97/claude-code-sub-agents) | Collection of specialized AI subagents for Claude Code | Specialized subagents|
 |[claude-agents](https://github.com/iannuttall/claude-agents) | ![GitHub Repo stars](https://badgen.net/github/stars/iannuttall/claude-agents) | Custom subagents to use with Claude Code | Custom subagents|
 


### PR DESCRIPTION
Adds [ranahaani/i-hate-editing](https://github.com/ranahaani/i-hate-editing) under Framework Extensions (next to other skill-oriented projects).

I'm the author. MIT Claude Code skill that edits talking-head video locally with whisper.cpp + ffmpeg without sending pixels to the model.

Happy to move the row if another section fits better.